### PR TITLE
use PlaneBufferGeometry with rotated X by -90° instead of BoxBufferGeometry

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,9 +372,8 @@ function createDefaultPlane (size) {
   var geometry;
   var material;
 
-  // @hack: Because I can't get THREE.BufferPlane working on raycaster.
-  geometry = new THREE.BoxBufferGeometry(size, 0.5, size);
-  geometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, -0.25, 0));
+  geometry = new THREE.PlaneBufferGeometry(100, 100);
+  geometry.rotateX(- Math.PI / 2)
   material = new THREE.MeshBasicMaterial({color: 0xffff00});
   return new THREE.Mesh(geometry, material);
 }


### PR DESCRIPTION
To be able to work with raycaster, you need to rotate the geometry, not the mesh.
With mesh rotation, you get `intersects[0].face.normal` = x: 0 y: 0: z: 1 and so your isValidNormalsAngle function returns false.
With the geometry rotation you get `intersects[0].face.normal` x: 0, y: 1, z: 1 and isValidNormalsAngle returns true.
I'll do a similar PR to aframe-environment-component, the generated ground geometry is currently a plane with a mesh rotation. If I do a similar fix and rotate the geometry and not the meshs, I can teleport on the hills! So much fun. :)