### PR TITLE
allow specify events to start/end teleport (fixes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,28 @@ Teleport component
 
 ## Properties
 
-| Property    | Description                     | Default Value    |
-| --------    | -----------                     | -------------    |
-| cameraRig       | Selector of the camera Rig to teleport         |    |
-| teleportOrigin | Selector of the child of cameraRig to use as the center point for teleporting, typically the camera. If set teleporting will position the cameraRig such that this element ends up above the teleport location (rather than the center of the camreaRig) |    |
-| type       | Type of teleport: line or parabolic         | parabolic   |
-| button       | Button used to launch the teleport: trackpad, trigger, grip, menu         | trackpad   |
-| collisionEntities | Selector of the meshes used to check the collisions. If no value provided a plane Y=0 is used |  |
-| hitEntity | Entity used to show at the hitting position. If no value provided a cylinder will be used as default. |           |
-| hitCylinderColor | Color used for the default `hitEntity` primitives | #99ff99          |
-| hitCylinderRadius | Radius used for the default `hitEntity` primitives | 0.25          |
-| hitCylinderHeight | Height used for the default `hitEntity` primitives | 0.3 |
-| curveHitColor | Color used for the curve when hit the mesh | #99ff99          |
-| curveMissColor | Color used for the curve when it doesn't hit anything | #ff0000          |
-| curveNumberPoints | Number of points used in the curve | 30          |
-| curveLineWidth | Line width of the curve | 0.025          |
-| curveShootingSpeed | Curve shooting speed, as bigger value, farther distance. | 5          |
-| defaultPlaneSize | Default plane size | 100 |
-| maxLength | Max length of the ray when using type=line teleport | 10 |
-| landingNormal | Normal vector to detect collisions with the `collisionEntity` | (0, 1, 0)          |
-| landingMaxAngle | Angle threshold (in degrees) used together with `landingNormal` to detect if the mesh is so steep to jump to it. | 45          |
+| Property           | Description                                                                                                                                                                                                                                              | Default Value |
+| --------           | -----------                                                                                                                                                                                                                                              | ------------- |
+| cameraRig          | Selector of the camera Rig to teleport                                                                                                                                                                                                                   |               |
+| teleportOrigin     | Selector of the child of cameraRig to use as the center point for teleporting, typically the camera. If set teleporting will position the cameraRig such that this element ends up above the teleport location (rather than the center of the camreaRig) |               |
+| type               | Type of teleport: line or parabolic                                                                                                                                                                                                                      | parabolic     |
+| button             | Button used to launch the teleport: trackpad, trigger, grip, menu                                                                                                                                                                                        | trackpad      |
+| collisionEntities  | Selector of the meshes used to check the collisions. If no value provided a plane Y=0 is used                                                                                                                                                            |               |
+| downEvents         | Alternative to `button`, list of events to listen to start telporting.                                                                                                                                                                                   | []            |
+| hitEntity          | Entity used to show at the hitting position. If no value provided a cylinder will be used as default.                                                                                                                                                    |               |
+| hitCylinderColor   | Color used for the default `hitEntity` primitives                                                                                                                                                                                                        | #99ff99       |
+| hitCylinderRadius  | Radius used for the default `hitEntity` primitives                                                                                                                                                                                                       | 0.25          |
+| hitCylinderHeight  | Height used for the default `hitEntity` primitives                                                                                                                                                                                                       | 0.3           |
+| curveHitColor      | Color used for the curve when hit the mesh                                                                                                                                                                                                               | #99ff99       |
+| curveMissColor     | Color used for the curve when it doesn't hit anything                                                                                                                                                                                                    | #ff0000       |
+| curveNumberPoints  | Number of points used in the curve                                                                                                                                                                                                                       | 30            |
+| curveLineWidth     | Line width of the curve                                                                                                                                                                                                                                  | 0.025         |
+| curveShootingSpeed | Curve shooting speed, as bigger value, farther distance.                                                                                                                                                                                                 | 5             |
+| defaultPlaneSize   | Default plane size                                                                                                                                                                                                                                       | 100           |
+| maxLength          | Max length of the ray when using type=line teleport                                                                                                                                                                                                      | 10            |
+| landingNormal      | Normal vector to detect collisions with the `collisionEntity`                                                                                                                                                                                            | (0, 1, 0)     |
+| landingMaxAngle    | Angle threshold (in degrees) used together with `landingNormal` to detect if the mesh is so steep to jump to it.                                                                                                                                         | 45            |
+| upEvents           | Paired with `downEvents`, list of events to listen for to finish teleporting.                                                                                                                                                                            | []            |
 
 ### Usage
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ AFRAME.registerComponent('teleport-controls', {
     type: {default: 'parabolic', oneOf: ['parabolic', 'line']},
     button: {default: 'trackpad', oneOf: ['trackpad', 'trigger', 'grip', 'menu']},
     collisionEntities: {default: ''},
+    downEvents: {type: 'array'},
+    upEvents: {type: 'array'},
     hitEntity: {type: 'selector'},
     cameraRig: {type: 'selector'},
     teleportOrigin: {type: 'selector'},
@@ -47,6 +49,7 @@ AFRAME.registerComponent('teleport-controls', {
   init: function () {
     var data = this.data;
     var el = this.el;
+    var i;
     var teleportEntity;
 
     this.active = false;
@@ -66,8 +69,20 @@ AFRAME.registerComponent('teleport-controls', {
     teleportEntity.setAttribute('visible', false);
     el.sceneEl.appendChild(this.teleportEntity);
 
-    el.addEventListener(data.button + 'down', this.onButtonDown.bind(this));
-    el.addEventListener(data.button + 'up', this.onButtonUp.bind(this));
+    // Add button/event listeners.
+    this.onButtonDown = this.onButtonDown.bind(this);
+    this.onButtonUp = this.onButtonUp.bind(this);
+    if (this.data.downEvents.length && this.data.upEvents.length) {
+      for (i = 0; i < this.data.downEvents.length; i++) {
+        el.addEventListener(this.data.downEvents[i], this.onButtonDown);
+      }
+      for (i = 0; i < this.data.upEvents.length; i++) {
+        el.addEventListener(this.data.upEvents[i], this.onButtonUp);
+      }
+    } else {
+      el.addEventListener(data.button + 'down', this.onButtonDown);
+      el.addEventListener(data.button + 'up', this.onButtonUp);
+    }
 
     this.queryCollisionEntities();
   },
@@ -257,7 +272,7 @@ AFRAME.registerComponent('teleport-controls', {
     rig.setAttribute('position', newRigLocalPosition);
 
     // If a rig was not explicitly declared, look for hands and mvoe them proportionally as well
-    if (!this.data.cameraRig) { 
+    if (!this.data.cameraRig) {
       var hands = document.querySelectorAll('a-entity[tracked-controls]');
       for (var i = 0; i < hands.length; i++) {
         var position = hands[i].getAttribute('position');


### PR DESCRIPTION
This allows me to specify however I want to use teleportation (e.g., trackpad clicked on the top, or trackpad clicked on the button). With this I use `teleport-controls="downEvents: teleportstart; upEvents: teleportend"` and I supply my own interaction.