### PR TITLE
update the note about teleport on generated ground

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ You can also use the trigger button instead of trackpad button by adding `button
 
 For Daydream, replace `gearvr-controls` by `daydream-controls`.
 
-If you use [aframe-environment-component](https://github.com/feiss/aframe-environment-component) > 1.0.0
-and want to teleport on the generated ground, on the hills, you can
-specify `collisionEntities: .environmentGround`. You can also add `.environmentDressing` if you want to teleport on the dressing like the mushrooms.
+If you use [aframe-environment-component](https://github.com/feiss/aframe-environment-component)
+and want to teleport on the generated ground, you can
+specify `collisionEntities: .environmentGround; landingNormal: 0 0 1;`.
 On Gear VR, it can be very slow with the curved line. Use `maxLength: 200; type: line;` in this case.
 
 


### PR DESCRIPTION
My commit in aframe-environment-component was reverted, so this was not accurate anymore. You need to change the landingNormal parameter for this to work, but you can't teleport on anything else though.