### PR TITLE
add an interval parameter for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Teleport component
 | hitCylinderColor | Color used for the default `hitEntity` primitives | #99ff99          |
 | hitCylinderRadius | Radius used for the default `hitEntity` primitives | 0.25          |
 | hitCylinderHeight | Height used for the default `hitEntity` primitives | 0.3 |
+| interval            | Number of milliseconds to wait in between each intersection test. Lower number is better for faster updates. Higher number is better for performance.              | 0           |
 | curveHitColor | Color used for the curve when hit the mesh | #99ff99          |
 | curveMissColor | Color used for the curve when it doesn't hit anything | #ff0000          |
 | curveNumberPoints | Number of points used in the curve | 30          |


### PR DESCRIPTION
Add an interval parameter to specify a number of milliseconds to wait in between each intersection test, similar to what we have in A-Frame raycaster component. I set the default interval to 0 so there is no change in behavior.

With giant meshes like the ground generated with the environment component, when aiming with GearVR controller the fps drops from 60 to 30.
Specify `interval: 100`, I have 50 fps which is much better.

You can use aframe-fps-counter-component to see the fps in vr mode like this:
```
<a-entity id="cameraRig">
  <a-entity
    class="right-controller"
    gearvr-controls
    teleport-controls="cameraRig: #cameraRig; button: trigger; maxLength: 200; type: line; interval: 100; landingMaxAngle: 135; collisionEntities: .environmentGround, .environmentDressing"
  >
    <a-entity fps-counter="for90fps: false" position="0 0 -1" />
  </a-entity>
</a-entity>
```
