### PR TITLE
Fix examples

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.2/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/common/mappings.js
+++ b/examples/common/mappings.js
@@ -1,18 +1,16 @@
 var mappings = {
-  mappings: {
-    default: {
-      common: {
-        trackpaddown: 'teleportstart',
-        trackpadup: 'teleportend'
-      },
-      'oculus-touch-controls': {
-        thumbstickdown: 'teleportstart',
-        thumbstickup: 'teleportend'
-      },
-      keyboard: {
-        't_down': 'teleportstart',
-        't_up': 'teleportend'
-      }
+  default: {
+    common: {
+      trackpaddown: 'teleportstart',
+      trackpadup: 'teleportend'
+    },
+    'oculus-touch-controls': {
+      thumbstickdown: 'teleportstart',
+      thumbstickup: 'teleportend'
+    },
+    keyboard: {
+      't_down': 'teleportstart',
+      't_up': 'teleportend'
     }
   }
 };

--- a/examples/custom/index.html
+++ b/examples/custom/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.2/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/custom/index.html
+++ b/examples/custom/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/mesh/index.html
+++ b/examples/mesh/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.2/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/mesh/index.html
+++ b/examples/mesh/index.html
@@ -4,7 +4,7 @@
     <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/multiple/index.html
+++ b/examples/multiple/index.html
@@ -5,7 +5,7 @@
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-motion-capture/343f99/dist/aframe-motion-capture.min.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">

--- a/examples/multiple/index.html
+++ b/examples/multiple/index.html
@@ -5,7 +5,7 @@
     <script src="../../dist/aframe-teleport-controls.min.js"></script>
     <script src="../common/shaders/skyGradient.js"></script>
     <script src="https://rawgit.com/ngokevin/aframe-motion-capture/343f99/dist/aframe-motion-capture.min.js"></script>
-    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.0/dist/aframe-input-mapping-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-input-mapping-component@0.1.2/dist/aframe-input-mapping-component.min.js"></script>
     <script src="../common/mappings.js"></script>
   </head>
   <body style="background-color: #000">


### PR DESCRIPTION
It seems that the latest version of aframe-input-mapping-component (0.1.3) isn't working with the current examples. I rolled back to the last-known working version (0.1.0) successfully and was then able to upgrade to 0.1.2 after tweaking the input mappings.

Looks like this fixes #55

The gh-pages branch will need an update too.